### PR TITLE
Add quotes in error messages in TestSuite

### DIFF
--- a/unit_test_framework/test_suite.gd
+++ b/unit_test_framework/test_suite.gd
@@ -29,7 +29,7 @@ func mark_test_failed(message: String) -> void:
 
 func assert_empty(array: Array) -> bool:
 	if not array.is_empty():
-		mark_test_failed("Expected empty array, got %s instead" % str(array))
+		mark_test_failed("Expected empty array, got \"%s\" instead" % str(array))
 		return false
 	return true
 	
@@ -43,42 +43,42 @@ func assert_not_empty(array: Array) -> bool:
 
 func assert_true(value: Variant) -> bool:
 	if not value:
-		mark_test_failed("Expected true, got %s" % str(value))
+		mark_test_failed("Expected true, got \"%s\"" % str(value))
 		return false
 	return true
 
 
 func assert_false(value: Variant) -> bool:
 	if value:
-		mark_test_failed("Expected false, got %s" % str(value))
+		mark_test_failed("Expected false, got \"%s\"" % str(value))
 		return false
 	return true
 		
 
 func assert_eq(value1: Variant, value2: Variant) -> bool:
 	if value1 != value2:
-		mark_test_failed("Expected equality between %s and %s" % [str(value1), str(value2)])
+		mark_test_failed("Expected equality between \"%s\" and \"%s\"" % [str(value1), str(value2)])
 		return false
 	return true
 		
 		
 func assert_ne(value1: Variant, value2: Variant) -> bool:
 	if value1 == value2:
-		mark_test_failed("Expected inequality between %s and %s" % [str(value1), str(value2)])
+		mark_test_failed("Expected inequality between \"%s\" and \"%s\"" % [str(value1), str(value2)])
 		return false
 	return true
 		
 		
 func assert_in(value: Variant, array: Array) -> bool:
 	if not value in array:
-		mark_test_failed("Expected %s to be in %s" % [str(value), str(array)])
+		mark_test_failed("Expected \"%s\" to be in %s" % [str(value), str(array)])
 		return false
 	return true
 
 	
 func assert_in_dict(value: Variant, dict: Dictionary) -> bool:
 	if not value in dict:
-		mark_test_failed("Expected %s to be in %s" % [str(value), str(dict)])
+		mark_test_failed("Expected \"%s\" to be in %s" % [str(value), str(dict)])
 		return false
 	return true
 	
@@ -93,6 +93,6 @@ func assert_array_size(array: Array, size: int) -> bool:
 func assert_string_match(string: String, pattern: String) -> bool:
 	var regex := RegEx.create_from_string(pattern)
 	if not regex.search(string):
-		mark_test_failed("Expected %s to match %s" % [string, pattern])
+		mark_test_failed("Expected \"%s\" to match \"%s\"" % [string, pattern])
 		return false
 	return true


### PR DESCRIPTION
Added quotes in error messages of the test framework where relevant
This will avoid having messages like "Expected true, got" when there is an empty string