### PR TITLE
Fixed command disappearing from suggestions once completed

### DIFF
--- a/command_tree/command_tree.gd
+++ b/command_tree/command_tree.gd
@@ -147,27 +147,34 @@ func get_autocomplete_suggestions(command: String) -> Array[String]:
 	
 	var last_node: Node = command_path[-1] if command_path.size() != 0 else self
 	
+	return _get_node_autocompletion(last_node, last_token, ends_with_whitespace)
+	
+	
+func _get_node_autocompletion(node: Node, last_token: String, ends_with_whitespace: bool) -> Array[String]:
 	if ends_with_whitespace:
 		var suggestions: Array[String] = []
-		for child in last_node.get_children():
+		for child in node.get_children():
 			if child is CommandTreeNode:
 				suggestions.append_array(child.get_autocomplete_suggestions(""))
 		return suggestions
 	else:
-		if last_node is CommandTreeArgument:
-			return last_node.get_autocomplete_suggestions(last_token)
-		elif last_node is Command:
+		if node is CommandTreeArgument:
+			return node.get_autocomplete_suggestions(last_token)
+		elif node is Command:
+			if last_token == node.command_name and (node.get_parent() is CommandTreeNode or node.get_parent() is CommandTree):
+				return _get_node_autocompletion(node.get_parent(), last_token, false)
+				
 			var suggestions: Array[String] = []
-			for child in last_node.get_children():
+			for child in node.get_children():
 				if child is CommandTreeNode:
 					suggestions.append_array(child.get_autocomplete_suggestions(last_token))
 			return suggestions
-		elif last_node is CommandTree:
+		elif node is CommandTree:
 			var suggestions: Array[String] = []
-			for child in last_node.get_children():
+			for child in node.get_children():
 				if child is Command:
 					suggestions.append_array(child.get_autocomplete_suggestions(last_token))
 			return suggestions
-	
-	push_error("Internal Error: Unhandled case")
+		
+	push_error("Internal Error: Trying to get autocompletion from unexpected node type")
 	return []

--- a/unit_tests/autocompletion_test.gd
+++ b/unit_tests/autocompletion_test.gd
@@ -45,3 +45,11 @@ func test_different_commands_space() -> void:
 	
 func test_enum_arg() -> void:
 	assert_same_array(command_tree.get_autocomplete_suggestions("time set "), ["day", "night", "noon", "midnight"])
+	
+	
+func test_command_end_still_shows() -> void:
+	assert_same_array(command_tree.get_autocomplete_suggestions("time"), ["time"])
+	
+	
+func test_arg_end_still_shows() -> void:
+	assert_same_array(command_tree.get_autocomplete_suggestions("time set day"), ["day"])


### PR DESCRIPTION
Before, if you had a `time set` command, and you typed `time`, the auto-completion would try to complete the time command arguments with the `time` token.
This caused problems with commands that start with the same name, as the typed command auto-completion would shadow the other commands.
Now, if the last token matches a command, the auto-completion suggestions will still be taken from the previous node instead of the typed command.