### PR TITLE
Fix get_command_path in preparse mode

### DIFF
--- a/command_tree/command_tree.gd
+++ b/command_tree/command_tree.gd
@@ -58,10 +58,12 @@ func get_command_path(
 		for child in children:
 			if not child.accepts_token_type(token_type):
 				continue
-			if not child.accepts_token(token):
+			if not child.accepts_token(token, preparse_mode):
 				continue
 			
 			if found_matching_node:
+				if preparse_mode:
+					return path
 				error = "Ambiguous command tree: token %s matches both %s and %s" % [token, node_to_string(path[-1]), node_to_string(child)]
 				return []
 			
@@ -161,7 +163,7 @@ func _get_node_autocompletion(node: Node, last_token: String, ends_with_whitespa
 		if node is CommandTreeArgument:
 			return node.get_autocomplete_suggestions(last_token)
 		elif node is Command:
-			if last_token == node.command_name and (node.get_parent() is CommandTreeNode or node.get_parent() is CommandTree):
+			if node.command_name.begins_with(last_token) and (node.get_parent() is CommandTreeNode or node.get_parent() is CommandTree):
 				return _get_node_autocompletion(node.get_parent(), last_token, false)
 				
 			var suggestions: Array[String] = []

--- a/command_tree/command_tree_node.gd
+++ b/command_tree/command_tree_node.gd
@@ -11,7 +11,7 @@ func accepts_token_type(_token_type: CommandParser.ArgumentType) -> bool:
 	
 
 ## Returns [code]true[/code] if this node accepts the given token, [code]false[/code] otherwise
-func accepts_token(_token: String) -> bool:
+func accepts_token(_token: String, _preparse_mode: bool = false) -> bool:
 	push_error("accepts_token not implemented for argument")
 	return false
 	

--- a/commands/arguments/bool_argument.gd
+++ b/commands/arguments/bool_argument.gd
@@ -6,7 +6,7 @@ func accepts_token_type(token_type: CommandParser.ArgumentType) -> bool:
 	return token_type == CommandParser.ArgumentType.BOOL
 	
 
-func accepts_token(_token: String) -> bool:
+func accepts_token(_token: String, _preparse_mode: bool = false) -> bool:
 	return true
 	
 	

--- a/commands/arguments/enum_argument.gd
+++ b/commands/arguments/enum_argument.gd
@@ -8,7 +8,9 @@ func accepts_token_type(token_type: CommandParser.ArgumentType) -> bool:
 	return token_type == CommandParser.ArgumentType.KEYWORD
 	
 	
-func accepts_token(token: String) -> bool:
+func accepts_token(token: String, preparse_mode: bool = false) -> bool:
+	if preparse_mode:
+		return possible_values.any(func(enum_val: String): return enum_val.begins_with(token))
 	return token in possible_values
 	
 	

--- a/commands/arguments/float_argument.gd
+++ b/commands/arguments/float_argument.gd
@@ -10,7 +10,7 @@ func accepts_token_type(token_type: CommandParser.ArgumentType) -> bool:
 		accepts_ints and token_type == CommandParser.ArgumentType.INT
 	)
 	
-func accepts_token(token: String) -> bool:
+func accepts_token(token: String, _preparse_mode: bool = false) -> bool:
 	return token.is_valid_float()
 	
 	

--- a/commands/arguments/int_argument.gd
+++ b/commands/arguments/int_argument.gd
@@ -6,7 +6,7 @@ func accepts_token_type(token_type: CommandParser.ArgumentType) -> bool:
 	return token_type == CommandParser.ArgumentType.INT
 	
 
-func accepts_token(token: String) -> bool:
+func accepts_token(token: String, _preparse_mode: bool = false) -> bool:
 	return token.is_valid_int()
 	
 

--- a/commands/arguments/json_argument.gd
+++ b/commands/arguments/json_argument.gd
@@ -6,7 +6,7 @@ func accepts_token_type(token_type: CommandParser.ArgumentType) -> bool:
 	return token_type == CommandParser.ArgumentType.JSON
 	
 	
-func accepts_token(_token: String) -> bool:
+func accepts_token(_token: String, _preparse_mode: bool = false) -> bool:
 	# Json tokens are assumed to be valid Json objects
 	return true
 	

--- a/commands/arguments/keyword_argument.gd
+++ b/commands/arguments/keyword_argument.gd
@@ -6,7 +6,9 @@ func accepts_token_type(token_type: CommandParser.ArgumentType) -> bool:
 	return token_type == CommandParser.ArgumentType.KEYWORD
 	
 	
-func accepts_token(token: String) -> bool:
+func accepts_token(token: String, preparse_mode: bool = false) -> bool:
+	if preparse_mode:
+		return self.argument_name.begins_with(token)
 	return token == self.argument_name
 	
 	

--- a/commands/arguments/string_argument.gd
+++ b/commands/arguments/string_argument.gd
@@ -6,7 +6,7 @@ func accepts_token_type(token_type: CommandParser.ArgumentType) -> bool:
 	return token_type == CommandParser.ArgumentType.STRING
 	
 	
-func accepts_token(_token: String) -> bool:
+func accepts_token(_token: String, _preparse_mode: bool = false) -> bool:
 	return true
 	
 	

--- a/commands/command.gd
+++ b/commands/command.gd
@@ -10,7 +10,9 @@ func accepts_token_type(token_type: CommandParser.ArgumentType) -> bool:
 	return token_type == CommandParser.ArgumentType.KEYWORD
 	
 
-func accepts_token(token: String) -> bool:
+func accepts_token(token: String, preparse_mode: bool = false) -> bool:
+	if preparse_mode:
+		return command_name.begins_with(token)
 	return token == command_name
 	
 	

--- a/unit_tests/autocompletion_test.gd
+++ b/unit_tests/autocompletion_test.gd
@@ -47,6 +47,10 @@ func test_enum_arg() -> void:
 	assert_same_array(command_tree.get_autocomplete_suggestions("time set "), ["day", "night", "noon", "midnight"])
 	
 	
+func test_enum_arg_partial() -> void:
+	assert_same_array(command_tree.get_autocomplete_suggestions("time set n"), ["night", "noon"])
+	
+	
 func test_command_end_still_shows() -> void:
 	assert_same_array(command_tree.get_autocomplete_suggestions("time"), ["time"])
 	
@@ -57,3 +61,7 @@ func test_arg_end_still_shows() -> void:
 	
 func test_keyword() -> void:
 	assert_same_array(command_tree.get_autocomplete_suggestions("param key"), ["keyword"])
+	
+	
+func test_after_keyword() -> void:
+	assert_same_array(command_tree.get_autocomplete_suggestions("spawn the_shade r"), ["random"])

--- a/unit_tests/data/command_tree_test.tscn
+++ b/unit_tests/data/command_tree_test.tscn
@@ -246,3 +246,19 @@ metadata/_custom_type_script = "uid://cehwf7xbnc5c3"
 script = ExtResource("8_5v886")
 argument_name = "keyword"
 metadata/_custom_type_script = "uid://gsppnmm8soku"
+
+[node name="Spawn" type="Node" parent="."]
+script = ExtResource("2_7l7ml")
+command_name = "spawn"
+metadata/_custom_type_script = "uid://cehwf7xbnc5c3"
+
+[node name="TheShade" type="Node" parent="Spawn"]
+script = ExtResource("8_5v886")
+argument_name = "the_shade"
+metadata/_custom_type_script = "uid://gsppnmm8soku"
+
+[node name="Where" type="Node" parent="Spawn/TheShade"]
+script = ExtResource("4_6bbis")
+possible_values = Array[String](["last", "random"])
+argument_name = "where"
+metadata/_custom_type_script = "uid://ds2t4tqqrl4g0"


### PR DESCRIPTION
Fix multiple situations where getting the command path would return the wrong path, because of argument types not accepting partial tokens